### PR TITLE
Long drush call causes an infinite loop, when not using ingest sets.

### DIFF
--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -264,6 +264,11 @@ function islandora_batch_ingest_process(array $parameters, &$context) {
       ($context['sandbox']['loops'] + 1) :
       1;
     $context['finished'] = 1.0 * $context['sandbox']['loops'] / ($context['sandbox']['loops'] + 1);
+    // This doesn't cause the job to be scheduled again,
+    // it just starts an infinite loop. So reset the timer.
+    if (isset($timers[ISLANDORA_BATCH_LOCK_TIMER])) {
+      unset($timers[ISLANDORA_BATCH_LOCK_TIMER]['time']);
+    }
   }
 
   $context['results']['timer'] = timer_stop(ISLANDORA_BATCH_TIMER_NAME);


### PR DESCRIPTION
The drupal timers are not reset when one is "started", so once you have used up 2/3 of the lock timeout. 

It tries to re-schedule it, except because we are re-using the same lock name then the first check still sees the previous runs time. 

So you are already over the 2/3rds of lock timeout. Rinse, repeat, ad infinitum. This just clears the time when you re-schedule.
