### PR TITLE
adds support for MARCXML record with collection wrapper

### DIFF
--- a/includes/islandora_scan_batch.inc
+++ b/includes/islandora_scan_batch.inc
@@ -379,7 +379,7 @@ class IslandoraScanBatchObject extends IslandoraBatchObject {
             $mods_datastream->setContentFromFile($this->objectInfo['xml']->uri, FALSE);
           }
           // MARCXML, transform to MODS and set.
-          elseif ($s_xml->getName() == 'record') {
+          elseif ($s_xml->getName() == 'collection' || 'record') {
             $mods_datastream->content = static::runXslTransform(array(
               'input' => $xml,
               'xsl' => $dir . '/transforms/MARC21slim2MODS3-4.xsl',

--- a/includes/islandora_scan_batch.inc
+++ b/includes/islandora_scan_batch.inc
@@ -379,7 +379,7 @@ class IslandoraScanBatchObject extends IslandoraBatchObject {
             $mods_datastream->setContentFromFile($this->objectInfo['xml']->uri, FALSE);
           }
           // MARCXML, transform to MODS and set.
-          elseif ($s_xml->getName() == 'collection' || 'record') {
+          elseif (in_array($s_xml->getName(), array('collection', 'record'))) {
             $mods_datastream->content = static::runXslTransform(array(
               'input' => $xml,
               'xsl' => $dir . '/transforms/MARC21slim2MODS3-4.xsl',


### PR DESCRIPTION
This patch adds support for a single MARCXML record with a collection
root element. Patch for [ISLANDORA-1184](https://jira.duraspace.org/browse/ISLANDORA-1184) 
