### PR TITLE
Alter locks acquired during preprocessing.

### DIFF
--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -98,13 +98,13 @@ function islandora_batch_get_lock_timeout($timeout) {
  * @param float $timeout
  *   The total amount of time for which we want to process a batch, in seconds.
  *   A negative value indicates that we are to be processing for an undefined
- *   amount of time.
+ *   amount of time. Defaults to -1.0.
  *
  * @return float|bool
  *   The amount of time for which a suitable lock was acquired, in seconds;
  *   otherwise, FALSE.
  */
-function islandora_batch_get_lock($ingest_set, $timeout) {
+function islandora_batch_get_lock($ingest_set, $timeout = -1.0) {
   $lock_timeout = islandora_batch_get_lock_timeout($timeout);
 
   $globally_locked = lock_acquire(ISLANDORA_BATCH_LOCK_NAME, $lock_timeout) ||

--- a/includes/preprocessor_base.inc
+++ b/includes/preprocessor_base.inc
@@ -35,6 +35,12 @@ abstract class IslandoraBatchPreprocessor {
   protected $setId;
 
   /**
+   * @var float $lockTime
+   *   The default amount of time for which to acquire our lock.
+   */
+  protected $lockTime = 30.0;
+
+  /**
    * Constructor must be able to receive an associative array of parameters.
    *
    * @param array $parameters
@@ -56,12 +62,28 @@ abstract class IslandoraBatchPreprocessor {
       ));
     $this->setId = $insert->execute();
 
-    $lock = lock_acquire('islandora_batch_processing');
+    $this->getLock();
+  }
+
+  /**
+   * Helper to acquire our lock.
+   *
+   * @return float
+   *   If we managed to acquire the lock, the amount of time in seconds for
+   *   which we acquired the lock; otherwise, we throw an exception.
+   *
+   * @throws IslandoraBatchFailedToLockException
+   *   If we failed to obtain the lock.
+   */
+  protected function getLock() {
+    require_once __DIR__ . '/ingest.batch.inc';
+    $lock = islandora_batch_get_lock($this->setId);
     if (!$lock) {
       throw new IslandoraBatchFailedToLockException(
           t('Failed to acquire lock for batch ingest.')
       );
     }
+    return $lock;
   }
 
   /**
@@ -71,12 +93,7 @@ abstract class IslandoraBatchPreprocessor {
    * serialized.
    */
   public function __wakeup() {
-    $lock = lock_acquire('islandora_batch_processing');
-    if (!$lock) {
-      throw new IslandoraBatchFailedToLockException(
-          t('Failed to acquire lock for batch ingest.')
-      );
-    }
+    $this->getLock();
   }
 
   /**

--- a/includes/preprocessor_base.inc
+++ b/includes/preprocessor_base.inc
@@ -35,12 +35,6 @@ abstract class IslandoraBatchPreprocessor {
   protected $setId;
 
   /**
-   * @var float $lockTime
-   *   The default amount of time for which to acquire our lock.
-   */
-  protected $lockTime = 30.0;
-
-  /**
    * Constructor must be able to receive an associative array of parameters.
    *
    * @param array $parameters
@@ -79,8 +73,10 @@ abstract class IslandoraBatchPreprocessor {
     require_once __DIR__ . '/ingest.batch.inc';
     $timer_name = __CLASS__ . "--SET:{$this->setId}";
     timer_start($timer_name);
-    while (timer_read($timer_name) < $this->lockTime * 1000) {
-      $lock = islandora_batch_get_lock($this->setId, $this->lockTime);
+    // Spend only up to 30 seconds spinning.
+    while (timer_read($timer_name) < 30 * 1000) {
+      // Attempt to get the lock for our set for the default amount of time.
+      $lock = islandora_batch_get_lock($this->setId);
       if (!$lock) {
         throw new IslandoraBatchFailedToLockException(
             t('Failed to acquire lock for batch ingest.')

--- a/includes/preprocessor_base.inc
+++ b/includes/preprocessor_base.inc
@@ -77,8 +77,9 @@ abstract class IslandoraBatchPreprocessor {
    */
   protected function getLock() {
     require_once __DIR__ . '/ingest.batch.inc';
-    timer_start(__CLASS__);
-    while (timer_read(__CLASS__) < $this->lockTime * 1000) {
+    $timer_name = __CLASS__ . "--SET:{$this->setId}";
+    timer_start($timer_name);
+    while (timer_read($timer_name) < $this->lockTime * 1000) {
       $lock = islandora_batch_get_lock($this->setId, $this->lockTime);
       if (!$lock) {
         throw new IslandoraBatchFailedToLockException(

--- a/includes/preprocessor_base.inc
+++ b/includes/preprocessor_base.inc
@@ -77,13 +77,16 @@ abstract class IslandoraBatchPreprocessor {
    */
   protected function getLock() {
     require_once __DIR__ . '/ingest.batch.inc';
-    $lock = islandora_batch_get_lock($this->setId);
-    if (!$lock) {
-      throw new IslandoraBatchFailedToLockException(
-          t('Failed to acquire lock for batch ingest.')
-      );
+    timer_start(__CLASS__);
+    while (timer_read(__CLASS__) < $this->lockTime * 1000) {
+      $lock = islandora_batch_get_lock($this->setId, $this->lockTime);
+      if (!$lock) {
+        throw new IslandoraBatchFailedToLockException(
+            t('Failed to acquire lock for batch ingest.')
+        );
+      }
+      return $lock;
     }
-    return $lock;
   }
 
   /**


### PR DESCRIPTION
Seems like it just wasn't updated when the idea of sets were introduced.

Because we were naive in acquiring the global lock, attempting to preprocess multiple sets concurrently would(/could?) fail.
