### PR TITLE
Allow the encoding of ZIP-contained filenames to be spec'd.

### DIFF
--- a/includes/islandora_scan_batch.inc
+++ b/includes/islandora_scan_batch.inc
@@ -92,7 +92,13 @@ class IslandoraScanBatch extends IslandoraBatchPreprocessor {
 
     $info = array();
     for ($i = 0; $i < $count; $i++) {
-      $name = $zip->getNameIndex($i);
+      $raw_name = $zip->getNameIndex($i, ZipArchive::FL_UNCHANGED);
+      if (isset($this->parameters['zip_encoding'])) {
+        $name = drupal_convert_to_utf8($raw_name, $this->parameters['zip_encoding']);
+      }
+      else {
+        $name = $zip->getNameIndex($i);
+      }
       $path_info = pathinfo($name);
 
       // Avoid creating entries for directories and some weird Mac stuff...
@@ -100,7 +106,7 @@ class IslandoraScanBatch extends IslandoraBatchPreprocessor {
       // $this::getPattern(), and to filter the results based on it.
       if (isset($path_info['extension']) && strpos($path_info['dirname'], '__MACOSX') === FALSE && $path_info['extension'] != 'DS_Store') {
         $file_entry = new stdClass();
-        $file_entry->uri = "zip://$zip_file#$name";
+        $file_entry->uri = "zip://$zip_file#$raw_name";
         $file_entry->filename = $path_info['basename'];
         $file_entry->name = $path_info['filename'];
         $info[$name] = $file_entry;

--- a/includes/islandora_scan_batch.inc
+++ b/includes/islandora_scan_batch.inc
@@ -93,7 +93,7 @@ class IslandoraScanBatch extends IslandoraBatchPreprocessor {
     $info = array();
     for ($i = 0; $i < $count; $i++) {
       $raw_name = $zip->getNameIndex($i, ZipArchive::FL_UNCHANGED);
-      if (isset($this->parameters['zip_encoding'])) {
+      if (isset($this->parameters['zip_encoding']) && trim($this->parameters['zip_encoding']) !=- '') {
         $name = drupal_convert_to_utf8($raw_name, $this->parameters['zip_encoding']);
       }
       else {

--- a/includes/islandora_scan_batch.inc
+++ b/includes/islandora_scan_batch.inc
@@ -93,7 +93,7 @@ class IslandoraScanBatch extends IslandoraBatchPreprocessor {
     $info = array();
     for ($i = 0; $i < $count; $i++) {
       $raw_name = $zip->getNameIndex($i, ZipArchive::FL_UNCHANGED);
-      if (isset($this->parameters['zip_encoding']) && trim($this->parameters['zip_encoding']) !=- '') {
+      if (isset($this->parameters['zip_encoding']) && trim($this->parameters['zip_encoding']) !== '') {
         $name = drupal_convert_to_utf8($raw_name, $this->parameters['zip_encoding']);
       }
       else {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -153,3 +153,55 @@ function islandora_batch_timer_reset($name) {
     $timers[$name]['time'] = 0;
   }
 }
+
+/**
+ * Helper to test if a given encoding will work.
+ *
+ * @param string $type
+ *   The "type" of target, we only care about "zip".
+ * @param string $encoding
+ *   The name of an encoding to test.
+ *
+ * @return NULL|string
+ *   NULL if we have not found an issue; otherwise, a string trying to describe
+ *   the issue.
+ */
+function islandora_batch_scan_check_encoding($type, $encoding) {
+  if ($type == 'zip' && $encoding) {
+    // Test parallel to drupal_convert_to_utf8().
+    if (function_exists('iconv')) {
+      $error_probe = function ($no = NULL, $str = NULL, $file = NULL, $line = NULL) {
+        static $found = FALSE;
+        $found = $found || $no !== NULL;
+        return $found;
+      };
+      set_error_handler($error_probe);
+      iconv_strlen('test', $encoding);
+      restore_error_handler();
+      if ($error_probe()) {
+        // XXX: "Should be supported", since PHP and the "iconv" command may be
+        // compiled against different libraries; however, this should be rare...
+        // hopefully?
+        return t('An invalid encoding has been specified for iconv; check "iconv -l" for a listing of those which should be supported.');
+      }
+    }
+    elseif (function_exists('mb_convert_encoding')) {
+      if (!(@mb_encoding_aliases($encoding) || in_array($encoding, mb_list_encodings()))) {
+        return t('An invalid encoding has been specified for mb_convert_encoding().');
+      }
+    }
+    elseif (function_exists('recode_string')) {
+      $error_probe = function ($no = NULL, $str = NULL, $file = NULL, $line = NULL) {
+        static $found = FALSE;
+        $found = $found || $no !== NULL;
+        return $found;
+      };
+      set_error_handler($error_probe);
+      recode_string("$encoding..utf8", 'test');
+      restore_error_handler();
+      if ($error_probe()) {
+        return t('An invalid encoding has been specified for recode_string().');
+      }
+    }
+  }
+}

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -109,7 +109,7 @@ function islandora_batch_drush_command() {
 }
 
 /**
- * Implemnents drush_COMMAND_validate() for islandora_batch_scan_preprocess.
+ * Implements drush_COMMAND_validate() for islandora_batch_scan_preprocess.
  */
 function drush_islandora_batch_scan_preprocess_validate() {
   module_load_include('inc', 'islandora_batch', 'includes/utilities');

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -81,6 +81,12 @@ function islandora_batch_drush_command() {
         'Defaults to namespace specified in Fedora configuration.',
         'value' => 'optional',
       ),
+      'zip_encoding' => array(
+        'description' => 'The encoding of filenames contained in ZIP ' .
+        'archives:Only relevant with --target=zip. Defaults to the native ' .
+        'encoding being used by PHP.',
+        'value' => 'optional',
+      ),
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
@@ -103,6 +109,17 @@ function islandora_batch_drush_command() {
 }
 
 /**
+ * Implemnents drush_COMMAND_validate() for islandora_batch_scan_preprocess.
+ */
+function drush_islandora_batch_scan_preprocess_validate() {
+  module_load_include('inc', 'islandora_batch', 'includes/utilities');
+  $encoding_check = islandora_batch_scan_check_encoding(drupal_strtolower(drush_get_option('type')), drush_get_option('zip_encoding'));
+  if ($encoding_check !== NULL) {
+    drush_set_error('INVALID ENCODING', $encoding_check);
+  }
+}
+
+/**
  * Implements hook_islandora_batch_scan_preprocess().
  *
  * Builds a preprocessor, and passes it off to a preprocessor handler.
@@ -122,6 +139,7 @@ function drush_islandora_batch_scan_preprocess() {
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', 'info:fedora/fedora-system:def/relations-external#'),
     'parent_relationship_pred' => drush_get_option('parent_relationship_pred', 'isMemberOfCollection'),
     'namespace' => drush_get_option('namespace'),
+    'zip_encoding' => drush_get_option('zip_encoding'),
   );
 
   if ($content_models = drush_get_option('content_models', FALSE)) {


### PR DESCRIPTION
Supercedes https://github.com/Islandora/islandora_batch/pull/72

[Encoding of filenames in ZIPs (and some other archive formats) is a strange beast](https://marcosc.com/2008/12/zip-files-and-encoding-i-hate-you/)... Specified as being either UTF-8 or CP437, utilities often ignore and go with the system encoding... Let's allow it to be specified as necessary.
