### PR TITLE
ISLANDORA-1522 global UUID setting enforcement

### DIFF
--- a/includes/preprocessor_base.inc
+++ b/includes/preprocessor_base.inc
@@ -121,9 +121,8 @@ abstract class IslandoraBatchPreprocessor {
     else {
       $namespace = $this->determineNamespace($object);
     }
-
     // TODO: Implement some form of caching, so we can get multiple at a time.
-    return $this->connection->repository->api->m->getNextPid($namespace);
+    return $this->connection->repository->getNextIdentifier($namespace);
   }
 
 


### PR DESCRIPTION
Addresses https://jira.duraspace.org/browse/ISLANDORA-1522

Makes use of repository getNextIdentifier() instead of calling directly
api-m method to allow our UUID enforcement to be applied
