### PR TITLE
Address ISLANDORA-1579.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Further documentation for this module is available at [our wiki](https://wiki.du
 
 The base ZIP/directory preprocessor can be called as a drush script (see `drush help islandora_batch_scan_preprocess` for additional parameters):
 
-`drush -v -u 1 --uri=http://localhost islandora_batch_scan_preprocess --type=zip --target=/path/to/archive.zip`
+`drush -v -u 1 --uri=http://localhost islandora_batch_scan_preprocess --type=zip --scan_target=/path/to/archive.zip`
 
 This will populate the queue (stored in the Drupal database) with base entries.
 
@@ -51,7 +51,7 @@ The queue of preprocessed items can then be processed:
 
 A fuller example, which preprocesses large image objects for inclusion in the collection with PID "yul:F0433", is:
 
-`drush -v -u 1 --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --target=/tmp/batch_ingest`
+`drush -v -u 1 --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --scan_target=/tmp/batch_ingest`
 
 then, to ingest the queued objects:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@ Further documentation for this module is available at [our wiki](https://wiki.du
 
 The base ZIP/directory preprocessor can be called as a drush script (see `drush help islandora_batch_scan_preprocess` for additional parameters):
 
+Drush made the `target` parameter reserved as of Drush 7. To allow for backwards compatability this will be preserved.
+
+Drush 7 and above:
+
 `drush -v -u 1 --uri=http://localhost islandora_batch_scan_preprocess --type=zip --scan_target=/path/to/archive.zip`
+
+Drush 6 and below:
+
+`drush -v -u 1 --uri=http://localhost islandora_batch_scan_preprocess --type=zip --target=/path/to/archive.zip`
 
 This will populate the queue (stored in the Drupal database) with base entries.
 
@@ -50,6 +58,12 @@ The queue of preprocessed items can then be processed:
 `drush -v -u 1 --uri=http://localhost islandora_batch_ingest`
 
 A fuller example, which preprocesses large image objects for inclusion in the collection with PID "yul:F0433", is:
+
+Drush 7 and above:
+
+`drush -v -u 1 --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --target=/tmp/batch_ingest`
+
+Drush 6 and below:
 
 `drush -v -u 1 --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --scan_target=/tmp/batch_ingest`
 

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -41,7 +41,7 @@ function islandora_batch_drush_command() {
     'ZIP archive.',
     'drupal dependencies' => array('islandora_batch'),
     'examples' => array(
-      'drush -v --user=admin --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --target=/tmp/batch_ingest',
+      'drush -v --user=admin --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --scan_target=/tmp/batch_ingest',
     ),
     'options' => array(
       'type' => array(
@@ -51,7 +51,7 @@ function islandora_batch_drush_command() {
         "`--directory` option.",
         'required' => TRUE,
       ),
-      'target' => array(
+      'scan_target' => array(
         'description' => 'The target to directory or zip file to scan.',
         'required' => TRUE,
       ),
@@ -83,7 +83,7 @@ function islandora_batch_drush_command() {
       ),
       'zip_encoding' => array(
         'description' => 'The encoding of filenames contained in ZIP ' .
-        'archives:Only relevant with --target=zip. Defaults to the native ' .
+        'archives:Only relevant with --scan_target=zip. Defaults to the native ' .
         'encoding being used by PHP.',
         'value' => 'optional',
       ),
@@ -134,7 +134,7 @@ function drush_islandora_batch_scan_preprocess() {
 
   $parameters = array(
     'type' => drush_get_option('type'),
-    'target' => drush_get_option('target'),
+    'scan_target' => drush_get_option('scan_target'),
     'parent' => drush_get_option('parent', variable_get('islandora_repository_pid', 'islandora:root')),
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', 'info:fedora/fedora-system:def/relations-external#'),
     'parent_relationship_pred' => drush_get_option('parent_relationship_pred', 'isMemberOfCollection'),

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -43,7 +43,7 @@ function islandora_batch_drush_command() {
     'examples' => array(
       format_string('drush -v --user=admin --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --@target=/tmp/batch_ingest',
       array(
-        '@target' => drush_core_version() >= 7 ? 'scan_target' : 'target',
+        '@target' => DRUSH_VERSION >= 7 ? 'scan_target' : 'target',
       )),
     ),
     'options' => array(
@@ -92,7 +92,7 @@ function islandora_batch_drush_command() {
   // backwards compatibility both will be supported. Not using
   // strict-option-handling (http://www.drush.org/en/master/strict-options) as
   // it requires manual argument parsing.
-  if (drush_core_version() >= 7) {
+  if (DRUSH_VERSION >= 7) {
     $items['islandora_batch_scan_preprocess']['options']['scan_target'] = array(
       'description' => 'The target to directory or zip file to scan.',
       'required' => TRUE,
@@ -148,7 +148,7 @@ function drush_islandora_batch_scan_preprocess() {
 
   $parameters = array(
     'type' => drush_get_option('type'),
-    'target' => drush_core_version() >= 7 ? drush_get_option('scan_target') : drush_get_option('target'),
+    'target' => DRUSH_VERSION >= 7 ? drush_get_option('scan_target') : drush_get_option('target'),
     'parent' => drush_get_option('parent', variable_get('islandora_repository_pid', 'islandora:root')),
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', 'info:fedora/fedora-system:def/relations-external#'),
     'parent_relationship_pred' => drush_get_option('parent_relationship_pred', 'isMemberOfCollection'),

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -41,7 +41,10 @@ function islandora_batch_drush_command() {
     'ZIP archive.',
     'drupal dependencies' => array('islandora_batch'),
     'examples' => array(
-      'drush -v --user=admin --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --scan_target=/tmp/batch_ingest',
+      format_string('drush -v --user=admin --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --@target=/tmp/batch_ingest',
+      array(
+        '@target' => drush_core_version() >= 7 ? 'scan_target' : 'target',
+      )),
     ),
     'options' => array(
       'type' => array(
@@ -51,15 +54,10 @@ function islandora_batch_drush_command() {
         "`--directory` option.",
         'required' => TRUE,
       ),
-      'scan_target' => array(
-        'description' => 'The target to directory or zip file to scan.',
-        'required' => TRUE,
-      ),
       'content_models' => array(
         'description' => 'Supports one or multiple comma-separated content ' .
         'models which are all applied to each ingested object.',
         'value' => 'optional',
-        // 'required' => FALSE,
       ),
       'parent' => array(
         'description' => 'The collection to which the generated items should ' .
@@ -90,6 +88,22 @@ function islandora_batch_drush_command() {
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
+  // XXX: The target parameter became reserved in Drush 7 and above, for
+  // backwards compatibility both will be supported. Not using
+  // strict-option-handling (http://www.drush.org/en/master/strict-options) as
+  // it requires manual argument parsing.
+  if (drush_core_version() >= 7) {
+    $items['islandora_batch_scan_preprocess']['options']['scan_target'] = array(
+      'description' => 'The target to directory or zip file to scan.',
+      'required' => TRUE,
+    );
+  }
+  else {
+    $items['islandora_batch_scan_preprocess']['options']['target'] = array(
+      'description' => 'The target to directory or zip file to scan.',
+      'required' => TRUE,
+    );
+  }
   $items['islandora_batch_cleanup_processed_sets'] = array(
     'aliases' => array('ibcps'),
     'description' => dt('Cleans up processed sets that have existed greater than a specified time.'),
@@ -134,7 +148,7 @@ function drush_islandora_batch_scan_preprocess() {
 
   $parameters = array(
     'type' => drush_get_option('type'),
-    'scan_target' => drush_get_option('scan_target'),
+    'target' => drush_core_version() >= 7 ? drush_get_option('scan_target') : drush_get_option('target'),
     'parent' => drush_get_option('parent', variable_get('islandora_repository_pid', 'islandora:root')),
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', 'info:fedora/fedora-system:def/relations-external#'),
     'parent_relationship_pred' => drush_get_option('parent_relationship_pred', 'isMemberOfCollection'),


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1579
# What does this Pull Request do?

Changes the `target` option to `scan_target`. The `target` option appears to clash (At least in drush 7.x) with drush's `target`. Changing it to a non-conflicting option namespace resolves the issue. Additionally, it provides backward compatibility for drush 6.x.
# How should this be tested?

Do a batch ingest with drush 6.x using the existing option, and do a batch ingest using drush 7.x with the new option.
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** No.

**Tagging:** @whikloj  

Release branch pull request: #80 
