### PR TITLE
Make scan batch get identifiers en masse for children as opposed to o…

### DIFF
--- a/includes/islandora_scan_batch.inc
+++ b/includes/islandora_scan_batch.inc
@@ -197,7 +197,7 @@ class IslandoraScanBatch extends IslandoraBatchPreprocessor {
         else {
           $namespace = $this->determineNamespace($object);
         }
-        $children_ids = $this->connection->repository->getNextIdentifier($namespace, NULL, $child_count);
+        $children_ids = (array) $this->connection->repository->getNextIdentifier($namespace, NULL, $child_count);
         foreach ($children_ids as $key => $id) {
           $children[$key]->id = $id;
           $this->preprocessChildren($children[$key], $object->id);

--- a/includes/islandora_scan_batch.inc
+++ b/includes/islandora_scan_batch.inc
@@ -198,9 +198,15 @@ class IslandoraScanBatch extends IslandoraBatchPreprocessor {
           $namespace = $this->determineNamespace($object);
         }
         $children_ids = (array) $this->connection->repository->getNextIdentifier($namespace, NULL, $child_count);
-        foreach ($children_ids as $key => $id) {
-          $children[$key]->id = $id;
-          $this->preprocessChildren($children[$key], $object->id);
+        foreach ($children as $child) {
+          $pid = array_shift($children_ids);
+          if ($pid !== NULL) {
+            $child->id = $pid;
+            $this->preprocessChildren($child, $object->id);
+          }
+          else {
+            throw new Exception(t('No PID was available to allocate for object.'));
+          }
         }
       }
     }

--- a/includes/islandora_scan_batch.inc
+++ b/includes/islandora_scan_batch.inc
@@ -188,9 +188,20 @@ class IslandoraScanBatch extends IslandoraBatchPreprocessor {
       $object->addRelationships();
       $this->addToDatabase($object, $object->getResources(), $parent);
       $to_return[] = $object;
-
-      foreach ($object->getChildren($this->connection) as $child) {
-        $to_return = array_merge($to_return, $this->preprocessChildren($child, $object->id));
+      $children = $object->getChildren($this->connection);
+      $child_count = count($children);
+      if ($child_count > 0) {
+        if (isset($this->parameters['namespace'])) {
+          $namespace = $this->parameters['namespace'];
+        }
+        else {
+          $namespace = $this->determineNamespace($object);
+        }
+        $children_ids = $this->connection->repository->getNextIdentifier($namespace, NULL, $child_count);
+        foreach ($children_ids as $key => $id) {
+          $children[$key]->id = $id;
+          $this->preprocessChildren($children[$key], $object->id);
+        }
       }
     }
     catch (Exception $e) {


### PR DESCRIPTION
…ne at a time.

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1855

# What does this Pull Request do?

When batches that extend scan batch (Islandora Book Batch / Islandora Newspaper Batch for example) go to preprocess children identifiers from Fedora will be requested all children at once in one request as opposed to doing a separate request for each child (n requests).

# What's new?
Requests are reduced from n to 1 for children of an object. This has big performance implications for objects that have a lot of direct children such as book pages.

# How should this be tested?

Use the Islandora Book Batch from the command line or the UI to ingest a book. Note that the `getNextPID` calls for pages ask for n pids at once as opposed to one at a time in the Fedora logs.

Example for two books with two pages each:
```
INFO 2017-02-09 17:45:42.417 [http-8080-10] (DefaultManagement) Completed getNextPID(numPIDs: 1, namespace: islandora)
INFO 2017-02-09 17:45:42.423 [http-8080-10] (DefaultManagement) Completed getNextPID(numPIDs: 2, namespace: islandora)
INFO 2017-02-09 17:45:42.435 [http-8080-10] (DefaultManagement) Completed getNextPID(numPIDs: 1, namespace: islandora)
INFO 2017-02-09 17:45:42.440 [http-8080-10] (DefaultManagement) Completed getNextPID(numPIDs: 2, namespace: islandora)

```

# Interested parties
@DiegoPino, @adam-vessey, @Islandora/7-x-1-x-committers
