### PR TITLE
7.x islandora batch 1880

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: php
 php:
   - 5.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,4 @@ script:
   - ant -buildfile sites/all/modules/islandora_batch/build.xml lint
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_batch
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer islandora_batch
-  - phpcpd --names *.module,*.inc,*.test --names-exclude *.views_default.inc sites/all/modules/islandora_batch
-  - drush test-run --uri=http://localhost:8081 "Islandora Batch"
+  - phpcpd --names *.module,*.inc,*.test --names-exclude *.views_default.inc sites/all/modules/islandora_batch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ before_install:
   - cd $HOME/drupal-*
   - ln -s $TRAVIS_BUILD_DIR sites/all/modules/islandora_batch
   - drush en --yes islandora_batch
+before_script:
+  # Mysql might time out for long tests, increase the wait timeout.
+  - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
 script:
   - ant -buildfile sites/all/modules/islandora_batch/build.xml lint
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_batch

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ script:
   - ant -buildfile sites/all/modules/islandora_batch/build.xml lint
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_batch
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer islandora_batch
-  - phpcpd --names *.module,*.inc,*.test --names-exclude *.views_default.inc sites/all/modules/islandora_batch"
+  - phpcpd --names *.module,*.inc,*.test --names-exclude *.views_default.inc sites/all/modules/islandora_batch


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1880

What does this Pull Request do?

Remove Travis-CI Drupal Test invocations made via Drush, which are being deprecated, as there are no tests in this repository. Updates the YAML to have a MySQL timeout so that long running tests don't cause the MySQL session to timeout. Lastly, adds sudo for the YAML as old builds were grandfathered.

What's new?

Removed the from Drush test runner script fro .travis.yml file. Added Sudo in .travis.yml file as it required for the scrips to run, repos before 2015 were grandfathered in. However, this isn't the case for forks. Also, added a before_script in travis.yml file to extend mysql wait time to 1200 as the builds were failing in Travic-ci.org.

Interested parties

@Islandora/7-x-1-x-committers