### PR TITLE
Islandora 1932

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Further documentation for this module is available at [our wiki](https://wiki.du
 The base ZIP/directory preprocessor can be called as a drush script (see `drush help islandora_batch_scan_preprocess` for additional parameters):
 
 Drush made the `target` parameter reserved as of Drush 7. To allow for backwards compatability this will be preserved.
+(`target` option requires the full path to your archive from root directory. e.g. /var/www/drupal/sites/archive.zip)
 
 Drush 7 and above:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Further documentation for this module is available at [our wiki](https://wiki.du
 The base ZIP/directory preprocessor can be called as a drush script (see `drush help islandora_batch_scan_preprocess` for additional parameters):
 
 Drush made the `target` parameter reserved as of Drush 7. To allow for backwards compatability this will be preserved.
-(`target` option requires the full path to your archive from root directory. e.g. /var/www/drupal/sites/archive.zip)
+The `target` option requires the full path to your archive from root directory. e.g. /var/www/drupal/sites/archive.zip
 
 Drush 7 and above:
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ A fuller example, which preprocesses large image objects for inclusion in the co
 
 Drush 7 and above:
 
-`drush -v -u 1 --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --target=/tmp/batch_ingest`
+`drush -v -u 1 --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --scan_target=/tmp/batch_ingest`
 
 Drush 6 and below:
 
-`drush -v -u 1 --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --scan_target=/tmp/batch_ingest`
+`drush -v -u 1 --uri=http://digital.library.yorku.ca islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=yul:F0433 --parent_relationship_pred=isMemberOfCollection --type=directory --target=/tmp/batch_ingest`
 
 then, to ingest the queued objects:
 

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -100,7 +100,7 @@ function islandora_batch_drush_command() {
   }
   else {
     $items['islandora_batch_scan_preprocess']['options']['target'] = array(
-      'description' => 'The target to directory or zip file to scan.',
+      'description' => 'The target to directory or zip file to scan. Requires the full path to your archive from root directory. e.g. /var/www/drupal/sites/archive.zip',
       'required' => TRUE,
     );
   }

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -94,7 +94,7 @@ function islandora_batch_drush_command() {
   // it requires manual argument parsing.
   if (DRUSH_VERSION >= 7) {
     $items['islandora_batch_scan_preprocess']['options']['scan_target'] = array(
-      'description' => 'The target to directory or zip file to scan.',
+      'description' => 'The target to directory or zip file to scan. Requires the full path to your archive from root directory. e.g. /var/www/drupal/sites/archive.zip',
       'required' => TRUE,
     );
   }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-1932](https://jira.duraspace.org/browse/ISLANDORA-1932)

* Other Relevant Links [wiki page with correct information](https://wiki.duraspace.org/display/ISLANDORA/Islandora+Batch)

# What does this Pull Request do?

Stresses the importance of using the full path from root for the `--target` or `--scan_target` options, and clarifies clashing information caused by typos regarding `--target` and `--scan_target` for changes between Drush 6 and Drush 7.

# What's new?
Not much new material introduced, just a simple documentation fix to lessen confusion. No new information added, but previously stated information is now made clear.

# How should this be tested?

* Verify that the information matches the wiki.
* Verify that wording is clear and free of typos.

# Additional Notes:
This is a pretty small documentation fix; it shouldn't cause any trouble.

# Interested parties
@Islandora/7-x-1-x-committers
