### PR TITLE
7.x islandora 1642

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -205,3 +205,94 @@ function islandora_batch_scan_check_encoding($type, $encoding) {
     }
   }
 }
+
+/**
+ * Helper to test scan target/target validity.
+ *
+ * @param string $type
+ *   The "type" of target, either "zip" or "directory".
+ * @param string $path
+ *   The path to the target.
+ *
+ * @return array
+ *   An array of arrays containing an error string and output label for
+ *   use in drush_set_error(). Empty if we encounter no errors.
+ */
+function islandora_batch_scan_check_target($type, $path) {
+  $errors = array();
+  if ($type == 'zip') {
+    if (DRUSH_VERSION >= 7) {
+      if (!is_readable($path)) {
+        $errors[] = array(
+          'error' => 'SCAN TARGET DOES NOT EXIST',
+          'label' => dt('"!target" does not exist or is not readable. ', array('!target' => $path)),
+        );
+      }
+      else {
+        if (!is_file($path)) {
+          $errors[] = array(
+            'error' => 'SCAN TARGET IS NOT A FILE',
+            'label' => dt('"!target" is not a file. ', array('!target' => $path)),
+          );
+        }
+      }
+    }
+    else {
+      if (!is_readable($path)) {
+        $errors[] = array(
+          'error' => 'TARGET DOES NOT EXIST',
+          'label' => dt('"!target" does not exist or is not readable. ', array('!target' => $path)),
+        );
+      }
+      else {
+        if (!is_file($path)) {
+          $errors[] = array(
+            'error' => 'TARGET IS NOT A FILE',
+            'label' => dt('"!target" is not a file. ', array('!target' => $path)),
+          );
+        }
+      }
+    }
+  }
+  elseif ($type == 'directory') {
+    if (DRUSH_VERSION >= 7) {
+      if (!is_readable($path)) {
+        $errors[] = array(
+          'error' => 'SCAN TARGET DOES NOT EXIST',
+          'label' => dt('"!target" does not exist or is not readable. ', array('!target' => $path)),
+        );
+      }
+      else {
+        if (!is_dir($path)) {
+          $errors[] = array(
+            'error' => 'SCAN TARGET IS NOT A DIRECTORY',
+            'label' => dt('"!target" is not a directory. ', array('!target' => $path)),
+          );
+        }
+      }
+    }
+    else {
+      if (!is_readable($path)) {
+        $errors[] = array(
+          'error' => 'TARGET DOES NOT EXIST',
+          'label' => dt('"!target" does not exist or is not readable. ', array('!target' => $path)),
+        );
+      }
+      else {
+        if (!is_dir($path)) {
+          $errors[] = array(
+            'error' => 'TARGET IS NOT A DIRECTORY',
+            'label' => dt('"!target" is not a directory. ', array('!target' => $path)),
+          );
+        }
+      }
+    }
+  }
+  else {
+    $errors[] = array(
+      'error' => 'INVALID TYPE OPTION',
+      'label' => dt('--type must be one of "directory" or "zip". '),
+    );
+  }
+  return $errors;
+}

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -131,31 +131,24 @@ function drush_islandora_batch_scan_preprocess_validate() {
   if ($encoding_check !== NULL) {
     drush_set_error('INVALID ENCODING', $encoding_check);
   }
-  $type = drush_get_option('type');
-  if ($type != 'zip' xor 'directory') {
-    drush_set_error('INVALID TYPE OPTION', $type, dt('--type must be one of "directory" or "zip".'));
+
+  $path = drush_get_option('scan_target') ? drush_get_option('scan_target') : drush_get_option('target');
+  $target_checks = islandora_batch_scan_check_target(drupal_strtolower(drush_get_option('type')), $path);
+  if (count($target_checks)) {
+    foreach ($target_checks as $target_check) {
+      drush_set_error($target_check['error'], NULL, $target_check['label']);
+    }
   }
+
   $cmodels = explode(',', drush_get_option('content_models'));
   foreach ($cmodels as $cmodel) {
     if (!islandora_object_load($cmodel)) {
-      drush_set_error('INVALID CONTENT MODEL', NULL, dt('!cmodel is not a valid content model. ', array('!cmodel' => $cmodel)));
+      drush_set_error('INVALID CONTENT MODEL', NULL, dt('"!cmodel" is not a valid content model. ', array('!cmodel' => $cmodel)));
     }
   }
   $parent = drush_get_option('parent');
   if (!islandora_object_load($parent)) {
-    drush_set_error('INVALID PARENT', NULL, dt('!parent does not exist or is not accessible. ', array('!parent' => $parent)));
-  }
-  if (DRUSH_VERSION >= 7) {
-    $scan_target = drush_get_option('scan_target');
-    if (!file_exists($scan_target)) {
-      drush_set_error('SCAN TARGET DOES NOT EXIST', dt('!target does not exist or is not readable. ', array('!target' => $scan_target)));
-    }
-  }
-  else {
-    $target = drush_get_option('target');
-    if (!file_exists($target)) {
-      drush_set_error('TARGET DOES NOT EXIST', NULL, dt('!target does not exist or is not readable. ', array('!target' => $target)));
-    }
+    drush_set_error('INVALID PARENT', NULL, dt('"!parent" does not exist or is not accessible. ', array('!parent' => $parent)));
   }
 }
 

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -131,6 +131,32 @@ function drush_islandora_batch_scan_preprocess_validate() {
   if ($encoding_check !== NULL) {
     drush_set_error('INVALID ENCODING', $encoding_check);
   }
+  $type = drush_get_option('type');
+  if ($type != 'zip' xor 'directory') {
+    drush_set_error('INVALID TYPE OPTION', $type);
+  }
+  $cmodels = explode(',', drush_get_option('content_models'));
+  foreach ($cmodels as $cmodel) {
+    if (!islandora_object_load($cmodel)) {
+      drush_set_error('INVALID CONTENT MODEL', $cmodel);
+    }
+  }
+  $parent = drush_get_option('parent');
+  if (!islandora_object_load($parent)) {
+    drush_set_error('INVALID PARENT', $parent);
+  }
+  if (DRUSH_VERSION >= 7) {
+    $scan_target = drush_get_option('scan_target');
+    if (!file_exists($scan_target)) {
+      drush_set_error('SCAN TARGET DOES NOT EXIST', $scan_target);
+    }
+  }
+  else {
+    $target = drush_get_option('target');
+    if (!file_exists($target)) {
+      drush_set_error('TARGET DOES NOT EXIST', $target);
+    }
+  }
 }
 
 /**

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -133,28 +133,28 @@ function drush_islandora_batch_scan_preprocess_validate() {
   }
   $type = drush_get_option('type');
   if ($type != 'zip' xor 'directory') {
-    drush_set_error('INVALID TYPE OPTION', $type);
+    drush_set_error('INVALID TYPE OPTION', $type, dt('--type must be one of "directory" or "zip".'));
   }
   $cmodels = explode(',', drush_get_option('content_models'));
   foreach ($cmodels as $cmodel) {
     if (!islandora_object_load($cmodel)) {
-      drush_set_error('INVALID CONTENT MODEL', $cmodel);
+      drush_set_error('INVALID CONTENT MODEL', NULL, dt('!cmodel is not a valid content model. ', array('!cmodel' => $cmodel)));
     }
   }
   $parent = drush_get_option('parent');
   if (!islandora_object_load($parent)) {
-    drush_set_error('INVALID PARENT', $parent);
+    drush_set_error('INVALID PARENT', NULL, dt('!parent does not exist or is not accessible. ', array('!parent' => $parent)));
   }
   if (DRUSH_VERSION >= 7) {
     $scan_target = drush_get_option('scan_target');
     if (!file_exists($scan_target)) {
-      drush_set_error('SCAN TARGET DOES NOT EXIST', $scan_target);
+      drush_set_error('SCAN TARGET DOES NOT EXIST', dt('!target does not exist or is not readable. ', array('!target' => $scan_target)));
     }
   }
   else {
     $target = drush_get_option('target');
     if (!file_exists($target)) {
-      drush_set_error('TARGET DOES NOT EXIST', $target);
+      drush_set_error('TARGET DOES NOT EXIST', NULL, dt('!target does not exist or is not readable. ', array('!target' => $target)));
     }
   }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1642

# What does this Pull Request do?

Adds some simple validation to the drush options `--type`, `--content_models`, `--parent`, and `--target`/`--scan_target`.

# What's new?

For each of the options listed above, performs simple validation, which, if it fails, fires a ` drush_set_error()` and exits.

# How should this be tested?

1. Check out https://github.com/mjordan/islandora_batch/tree/7.x-ISLANDORA-1642
1. Run the following drush command: `drush -v -u 1 islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmode --parent=some:collection --parent_relationship_pred=isMemberOfCollection --type=directory --target=/tmp/foobarbaz`

You should see the following output:

```
Initialized Drupal site default at sites/default                                                                                                 [notice]
islandora:sp_large_image_cmode is not a valid content model. INVALID CONTENT MODEL                                                             [error]
some:collection does not exist or is not accessible. INVALID PARENT                                                                            [error]
/tmp/foobarbaz does not exist or is not readable. TARGET DOES NOT EXIST                                                                        [error]
Command dispatch complete                                                                                                                         [notice]
```


# Additional Notes:
Similar validation should be incorporated into the other batch modules.

# Interested parties
@rosiel  @Islandora/7-x-1-x-committers
