### PR TITLE
ISLANDORA=1933 error message explains absolute path is necessary.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -259,7 +259,7 @@ function islandora_batch_scan_check_target($type, $path) {
       if (!is_readable($path)) {
         $errors[] = array(
           'error' => 'SCAN TARGET DOES NOT EXIST',
-          'label' => dt('"!target" does not exist or is not readable. ', array('!target' => $path)),
+          'label' => dt('"!target" does not exist as an absolute path or is not readable. ', array('!target' => $path)),
         );
       }
       else {
@@ -275,7 +275,7 @@ function islandora_batch_scan_check_target($type, $path) {
       if (!is_readable($path)) {
         $errors[] = array(
           'error' => 'TARGET DOES NOT EXIST',
-          'label' => dt('"!target" does not exist or is not readable. ', array('!target' => $path)),
+          'label' => dt('"!target" does not exist as an absolute path or is not readable. ', array('!target' => $path)),
         );
       }
       else {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -225,7 +225,7 @@ function islandora_batch_scan_check_target($type, $path) {
       if (!is_readable($path)) {
         $errors[] = array(
           'error' => 'SCAN TARGET DOES NOT EXIST',
-          'label' => dt('"!target" does not exist or is not readable. ', array('!target' => $path)),
+          'label' => dt('"!target" does not exist as an absolute path or is not readable. ', array('!target' => $path)),
         );
       }
       else {
@@ -241,7 +241,7 @@ function islandora_batch_scan_check_target($type, $path) {
       if (!is_readable($path)) {
         $errors[] = array(
           'error' => 'TARGET DOES NOT EXIST',
-          'label' => dt('"!target" does not exist or is not readable. ', array('!target' => $path)),
+          'label' => dt('"!target" does not exist as an absolute path or is not readable. ', array('!target' => $path)),
         );
       }
       else {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1933

* Other Related Tickets*:
https://jira.duraspace.org/browse/ISLANDORA-1642
https://jira.duraspace.org/browse/ISLANDORA-1932

# What does this Pull Request do?

Makes the error messages more instructive.

# What's new?

If the target/scan_target is not found, it mentions an absolute path must be given.

# How should this be tested?

1. From a folder under Drupal root containing a readable file Archive.zip, 

2. Run the following drush command (--target assuming drush 6 or below; for drush 7+ use --scan_target): `drush -v -u 1 islandora_batch_scan_preprocess --content_models=islandora:sp_large_image_cmodel --parent=islandora:root --parent_relationship_pred=isMemberOfCollection --type=zip --target=./Archive.zip`

If you can figure out from the error message what's wrong, then it worked. 

# Additional Notes:

This is a tiny modification to @mjordan's awesome work making these error messages.

# Interested parties
@bondjimbond, @mjordan 