### PR TITLE
attempts to give the ingest object title when an ingest fails

### DIFF
--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -404,7 +404,11 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
       $process_results = $ingest_object->batchProcess();
       $object['state'] = is_array($process_results) ? $process_results['state'] : $process_results;
     }
-
+    try {
+      $error_text = $ingest_object->label;
+    } catch (Exception $ex) {
+      $error_text = "[unable to get any information about the failed ingest object]";
+    }
     if ($object['state'] === ISLANDORA_BATCH_STATE__DONE) {
       try {
         // XXX: Due to how the things currently work, the user name and
@@ -420,22 +424,22 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
         $ingested_object = islandora_add_object($ingest_object);
         if ($ingested_object) {
           $object['data'] = serialize($ingested_object);
-          $context['message'] = t('Ingested %pid.', array('%pid' => $ingested_object->id));
+          $context['message'] = t("Ingested {$ingested_object->id}");
         }
         else {
           // Failed to ingest...  Flag an error.
           $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-          $context['message'] = t('Unknown error: Failed to ingest %pid.', array('%pid' => $ingest_object->id));
+          $context['message'] = t("Unknown error: Failed to ingest {$error_text}");
         }
       }
       catch (Exception $e) {
         // Failed to ingest...  Flag an error.
         $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-        $context['message'] = t('Exception occured: Failed to ingest %pid.', array('%pid' => $ingest_object->id));
+        $context['message'] = t("Exception occured: Failed to ingest {$error_text}");
       }
     }
     else {
-      $context['message'] = t('%pid not ready for ingest.', array('%pid' => $ingest_object->id));
+      $context['message'] = t("{$error_text} not ready for ingest.");
     }
 
     // Update the info in the database.

--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -405,9 +405,10 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
       $object['state'] = is_array($process_results) ? $process_results['state'] : $process_results;
     }
     try {
-      $error_text = $ingest_object->label;
-    } catch (Exception $ex) {
-      $error_text = "[unable to get any information about the failed ingest object]";
+      $object_title = $ingest_object->label;
+    }
+    catch (Exception $ex) {
+      $object_title = "[unable to get any information about the failed ingest object]";
     }
     if ($object['state'] === ISLANDORA_BATCH_STATE__DONE) {
       try {
@@ -424,22 +425,28 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
         $ingested_object = islandora_add_object($ingest_object);
         if ($ingested_object) {
           $object['data'] = serialize($ingested_object);
-          $context['message'] = t("Ingested {$ingested_object->id}");
+          $context['message'] = t('Ingested %pid.', array('%pid' => $ingested_object->id));
         }
         else {
           // Failed to ingest...  Flag an error.
           $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-          $context['message'] = t("Unknown error: Failed to ingest {$error_text}");
+          $context['message'] = t('Unknown error: Failed to ingest %pid  Title: %object_title', array(
+            '%pid' => $ingested_object->id, '%object_title' => $object_title)
+            );
         }
       }
       catch (Exception $e) {
         // Failed to ingest...  Flag an error.
         $object['state'] = ISLANDORA_BATCH_STATE__ERROR;
-        $context['message'] = t("Exception occured: Failed to ingest {$error_text}");
+        $context['message'] = t('Exception occured: Failed to ingest %pid  Title: %object_title', array(
+          '%pid' => $ingested_object->id, '%object_title' => $object_title)
+          );
       }
     }
     else {
-      $context['message'] = t("{$error_text} not ready for ingest.");
+      $context['message'] = t('%pid not ready for ingest.  Title: %object_title', array(
+        '%pid' => $ingested_object->id, '%object_title' => $object_title)
+        );
     }
 
     // Update the info in the database.


### PR DESCRIPTION
Currently, when an item fails to ingest -- there is a message posted at Islandora Batch Ingest Queue.  The messages states something happened & the pid which item would have been given.  Since the item is not ingested, the pid does not exist in Islandora.  You can see how this error message does not assist in identifying which item failed.

This commit attempts to lookup the item's title.  While another variable may be more descriptive, this was the best one available at this scope.  (the others are protected variables.)  At least "title" will give the user some help in identifying which ingest object is failing.

In the instance where the ingest object was created, the Ingest Queue names the newly made pid.  All other instances were changed to report "title" if possible.

Does not affect functionality.  Only affects display output at the Reports/IslandoraBatchIngestQueue/.

Do a batch zip ingest (simple object) of this zip package of 3 mods objects.  One should pass.  Two should fail.  One has a title.  The other has no title (to prove that an absent title causes no crash).  

[test_cases_for_zip_simple_object_batch_ingest.zip](https://github.com/Islandora/islandora_batch/files/1137056/test_cases_for_zip_simple_object_batch_ingest.zip)

![ingestqueueoutput](https://user-images.githubusercontent.com/6989085/28039598-92b987e6-6588-11e7-8a15-e0224c508a64.png)
