### PR TITLE
don't overwrite serialized object

### DIFF
--- a/includes/ingest.batch.inc
+++ b/includes/ingest.batch.inc
@@ -419,7 +419,6 @@ function islandora_batch_process_results($results, $timeout, $lock_timeout, &$co
         // Push to backend.
         $ingested_object = islandora_add_object($ingest_object);
         if ($ingested_object) {
-          $object['data'] = serialize($ingested_object);
           $context['message'] = t('Ingested %pid.', array('%pid' => $ingested_object->id));
         }
         else {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2055

Bears some relation to https://jira.duraspace.org/browse/ISLANDORA-2046

# What does this Pull Request do?

Stops the batch ingest processor from overwriting the preprocessor object in the database with the ingested object.

# What's new?
This is a small change with a big impact and may merit some discussion surrounding the way that people use the Islandora batch interface to ensure we aren't stepping on toes.

Some quick background: batch works by generating `IslandoraBatchObject` objects (an extension of the `IslandoraNewFedoraObject` class; essentially an uningested Fedora object), serializing them, and placing them in the database. When the batch processor is called, the object is unserialized and the object's `batchProcess()` function is called.

If the object reports that batch processing was successful, the batch process handler overwrites the serialized `IslandoraBatchObject` in the database with a serialized version of the new `IslandoraFedoraObject`

The thing is: there doesn't seem to be any point to doing this. Worse, it means information about the batch is lost on success, making it impossible to re-run the batch in situations that the processor may have failed to catch (or just plain isn't responsible for)

This PR essentially proposes that we leave the `IslandoraBatchObject` where it was in the database, even on success. While I can't imagine why anyone would want the `IslandoraFedoraObject` to be in there or be relying on it (why not load the actual object?), this is akin to an API change and requires the related due process.

# How should this be tested?

* Preprocess a batch. Any kind of batch will do; this is batch-type-agnostic.
* Process the batch; ensure all objects were successfully ingested.
* Head to `admin/reports/islandora_batch_sets`
* Use the drop-down menu to the right of your set to "Purge objects", and do so.
* Use the same drop-down menu to "Set item states". Change the item states from "Any" to "Ready to ingest"
* Use the drop-down menu again to "Restart batch" (this is a bit of a misnomer; it just attempts to process any items that aren't ingested or errored)

Former behaviour: An error will occur (`Call to undefined method IslandoraFedoraObject::batchProcess()`), as the overwritten objects don't have `batchProcess()` methods
New behaviour: The items will be re-ingested

Note that the entire test process will have to be re-run after switching to this pull, since the old `IslandoraBatchObject`s will be lost.

# Interested parties
Being maintained by @adam-vessey and particularly @DiegoPino as this will play into his recommendation in ISLANDORA-2046