### PR TITLE
Use parent collection namespace as default if not configured

### DIFF
--- a/includes/preprocessor_base.inc
+++ b/includes/preprocessor_base.inc
@@ -144,8 +144,7 @@ abstract class IslandoraBatchPreprocessor {
       return NULL;
     }
     $parent_pid = $this->parameters['parent'];
-    // Not specifying a namespace should result in one from the default
-    // declared in the fedora.fcfg ("changeme" by default).
+    // Not specifying a namespace defaults to using the parent collection's namespace. 
     $namespace = explode(":", $parent_pid)[0];
     if (module_exists('islandora_basic_collection') && !isset($collection_policies[$parent_pid])) {
       $parent = islandora_object_load($parent_pid);

--- a/includes/preprocessor_base.inc
+++ b/includes/preprocessor_base.inc
@@ -147,8 +147,6 @@ abstract class IslandoraBatchPreprocessor {
     // Not specifying a namespace should result in one from the default
     // declared in the fedora.fcfg ("changeme" by default).
     $namespace = explode(":", $parent_pid)[0];
-dd($namespace);
-//    $namespace = NULL;
     if (module_exists('islandora_basic_collection') && !isset($collection_policies[$parent_pid])) {
       $parent = islandora_object_load($parent_pid);
       if (isset($parent['COLLECTION_POLICY'])) {

--- a/includes/preprocessor_base.inc
+++ b/includes/preprocessor_base.inc
@@ -146,7 +146,9 @@ abstract class IslandoraBatchPreprocessor {
     $parent_pid = $this->parameters['parent'];
     // Not specifying a namespace should result in one from the default
     // declared in the fedora.fcfg ("changeme" by default).
-    $namespace = NULL;
+    $namespace = explode(":", $parent_pid)[0];
+dd($namespace);
+//    $namespace = NULL;
     if (module_exists('islandora_basic_collection') && !isset($collection_policies[$parent_pid])) {
       $parent = islandora_object_load($parent_pid);
       if (isset($parent['COLLECTION_POLICY'])) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2249

# What does this Pull Request do?

When batch ingesting via drush, uses parent collection's namespace as the default if not defined in collection policy.

# What's new?

Previously, if you ingested a batch with a Cmodel not configured in the parent's collection policy, Islandora would set it to NULL, which meant use the Fedora default (probably "changeme" if not otherwise configured). With this PR, Batch checks the parent's namespace and uses that as the default instead.

# How should this be tested?

* Create a collection with a special namespace (e.g. "testnamespace"), and one content model (e.g. video) defined in its policy to use the "testnamespace" namespace.
* Create a batch ingest to that collection, in a cmodel _not_ defined by the collection policy (e.g. large image).
* Note that the namespace the objects are ingested to is the Fedora default.
* Check out this branch.
* Run the batch ingest again (preprocess, then ingest).
* Note that the batch now uses the parent's namespace for the new objects.
* Alter the collection policy, enable this cmodel, and create a new namespace for it (e.g. "mynewnamespace").
* Run the batch ingest again (preprocess, then ingest).
* Note that the objects now use the configured namespace from the collection policy.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
