### PR TITLE
Add --output_set_id flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ After successful ingest, if the Drupal batch sets are not automatically cleared 
 
 where the `--time` parameter is a Unix timestamp. This will delete sets that were marked completed before (i.e. older than) the given timestamp. For example, to calculate the timestamp for 24h ago, use `date +%s` from a unix terminal then subtract 86,400 seconds.
 
+#### Outputting the set id
+Currently the default behaviour of the `islandora_batch_scan_preprocess` command is to output the set id as `SetId: <set id>`.
+
+Now there is an optional flag `--output_set_id` which causes `islandora_batch_scan_preprocess` to **only** output the set id number.
+
+This behaviour is the same as [Islandora Book Batch](https://github.com/islandora/islandora_book_batch) and 
+[Islandora Newspaper Batch](https://github.com/islandora/islandora_newspaper_batch).
+
+The default behaviour (outputting with `SetId:` prefix) has been left alone to avoid backwards compatibility issues. 
+
 ### Customization
 
 Custom ingests can be written by [extending](https://github.com/Islandora/islandora_batch/wiki/How-To-Extend) any of the existing preprocessors and batch object implementations. Checkout the [example implemenation](https://github.com/Islandora/islandora_batch/wiki/Example-Implementation-Tutorial) for more details.

--- a/islandora_batch.drush.inc
+++ b/islandora_batch.drush.inc
@@ -85,6 +85,10 @@ function islandora_batch_drush_command() {
         'encoding being used by PHP.',
         'value' => 'optional',
       ),
+      'output_set_id' => array(
+        'description' => 'A flag to indicate whether to print the set ID of the preprocessed objects.',
+        'value' => 'optional',
+      ),
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
@@ -188,7 +192,15 @@ function drush_islandora_batch_scan_preprocess() {
 
   // Pass the preprocessor off to run.
   $preprocessed = islandora_batch_handle_preprocessor($preprocessor);
-  drush_log(t("SetId: @s", array('@s' => $preprocessor->getSetId())), "ok");
+
+  if (drush_get_option('output_set_id', FALSE)) {
+    // If you choose the --output_set_id we only print the ID.
+    drush_print($preprocessor->getSetId());
+  }
+  else {
+    // This is the default for backwards compatibility sake.
+    drush_log(t("SetId: @s", array('@s' => $preprocessor->getSetId())), "ok");
+  }
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1875

https://github.com/Islandora/islandora_newspaper_batch/pull/38

# What does this Pull Request do?

Add a new drush option to output the set id when executed on the command line.

# How should this be tested?

Pull in the PR.
Pre-process some object both setting and not setting the `--output_set_id`.

When finished:
* if you set the `--output_set_id` flag you will _just_ see the id.
* if you did _not_ set the `--output_set_id` flag you will see `SetId: <set id>`

# Additional Notes:

Example:
* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? Included
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers @Bradspry
